### PR TITLE
fix: typo `marked` should be `make`

### DIFF
--- a/presentations/src/main/asciidoc/release_management_cn.adoc
+++ b/presentations/src/main/asciidoc/release_management_cn.adoc
@@ -139,7 +139,7 @@ image::OpenSourceCamp.jpeg[]
 [source]
 ----
 $ ./configure
-$ marked
+$ make
 # make install
 ----
 * Java项目，使用maven


### PR DESCRIPTION
The `marked` in "编译与安装" section seems to be a typo of `make`